### PR TITLE
use json_class_no_name for array element

### DIFF
--- a/src/ti_object.cpp
+++ b/src/ti_object.cpp
@@ -28,8 +28,15 @@ namespace daw::json_to_cpp::types {
 	std::string ti_object::json_name( daw::string_view member_name,
 	                                  bool use_cpp20,
 	                                  daw::string_view parent_name ) const {
+		auto const gen_member_name = impl::format_member_name( member_name, use_cpp20, parent_name );
+		if (gen_member_name == "no_name") {
+			// array member should not have name
+			// json_class_no_name<data_element_t>
+			return "json_class_no_name<" + name( ) + ">";
+		}
+		// json_class<"name", data_element_t>
 		return "json_class<" +
-		       impl::format_member_name( member_name, use_cpp20, parent_name ) +
+		       gen_member_name +
 		       ", " + name( ) + ">";
 	}
 


### PR DESCRIPTION
**Issue**

If we have a list of class as input:
```json
{
  "object": "world",
  "data": [
    {
      "id": "string",
    }
  ]
}
```

`json_to_cpp`  generate this:

```cpp
namespace daw::json {
	template<>
	struct json_data_contract<Models_t> {
		static constexpr char const mem_object[] = "object";
		static constexpr char const mem_data[] = "data";
		 using type = json_member_list<
				json_string<mem_object>
				,json_array<mem_data, json_class<no_name, data_element_t>, std::vector<data_element_t>>
	>;  // <-- the issue

		static inline auto to_json_data( Models_t const & value ) {
			return std::forward_as_tuple( value.object, value.data );
}
	};
}
```

`json_class<no_name, data_element_t>,` doesn't compile.
In order to use no_name element, we need to use 
`json_class_no_name<data_element_t>`